### PR TITLE
Bump Atlassian versions (Atlassian-CVE-2022-26136)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
       matrix:
         include:
           - name: bitbucket
-            version: 7.21.0
+            version: 7.21.3
           - name: bamboo
-            version: 8.1.3
+            version: 8.1.8
           - name: bamboo-build-agent
-            version: 8.1.3
+            version: 8.1.8
           - name: jira
-            version: 8.20.6
+            version: 8.20.10
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Jira -> 8.20.10
- Bitbucket -> 7.21.3
- Bamboo -> 8.1.8

REF: https://confluence.atlassian.com/security/multiple-products-security-advisory-cve-2022-26136-cve-2022-26137-1141493031.html