### PR TITLE
`Development:` Fix build args version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          build-args: ${{ matrix.version }}
+          build-args: VERSION=${{ matrix.version }}
           context: ./${{ matrix.name }}
           file: ./${{ matrix.name }}/Dockerfile
           platforms: linux/arm64/v8,linux/amd64


### PR DESCRIPTION
Currently the version ARG is provided to the Dockerfile without specifying the ARG itself, so instead of receiving the ARG as `VERSION=1.2.3` the Dockerfile just receives the version on its own `1.2.3`. This PR fixes that. 