### PR TITLE
`Development:` Set fail fast strategy to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     name: Build and Push the Docker Images
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: bitbucket


### PR DESCRIPTION
Currently the bitbucket build fails. Since we use a strategy matrix by default the other builds do not continue when one of the builds fails. This PR sets `fail-fast: false` so the other builds continue even if one of the other builds fails. 
This will hopefully allow the bamboo image to build even if the bitbucket build fails currently. 
And since the main Artemis project has `bamboo-spec: 8.1.8` as dependency, our current bamboo version 8.1.3 is not compatible. 